### PR TITLE
gofmt compatibility

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,7 +91,6 @@ func main() {
 	}
 	if diffs > 0 {
 		fmt.Printf("Found %d diffs\n", diffs)
-		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
`os.Exit(1)` doesn't fit with the other `gofmt`-style linters (see `fatih/hclfmt`, or even `gofmt` for example). Ran into this after trying to add `:Crlfmt` support to vim, copying from vim-go.
This doesn't break `build/style_test.go`, we don't use the error code as the failure indicator.

cc @tamird 
