### PR TITLE
Fix panic on forward declaration

### DIFF
--- a/main.go
+++ b/main.go
@@ -126,7 +126,12 @@ func checkPath(path string) (int, error) {
 			results := f.Type.Results
 
 			opening := params.Pos() + 1
-			closing := f.Body.Pos() + 1
+			closing := f.Type.End()
+			// f.Body is nil if the FuncDecl is a forward declaration.
+			if f.Body != nil {
+				closing = f.Body.Pos() + 1
+			}
+
 			maybeWrite(output, fileBytes[fset.Position(lastPos).Offset:fset.Position(opening).Offset])
 			lastPos = closing
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"io/ioutil"
+	"testing"
+)
+
+var inDir = "testdata/"
+
+func TestCheckPath(t *testing.T) {
+	files, err := ioutil.ReadDir(inDir)
+	if err != nil {
+		t.Error(err)
+	}
+	for _, file := range files {
+		t.Run(file.Name(), func(t *testing.T) {
+			inPath := inDir + file.Name()
+
+			diffs, err := checkPath(inPath)
+			if err != nil {
+				t.Error(err)
+			}
+			if diffs != 0 {
+				t.Errorf("expected 0 diffs but got %d", diffs)
+			}
+		})
+	}
+}

--- a/testdata/_cgo_gotypes.go
+++ b/testdata/_cgo_gotypes.go
@@ -1,0 +1,34 @@
+//go:cgo_ldflag "-static-libgcc"
+//go:cgo_ldflag "-static-libstdc++"
+//go:cgo_ldflag "-Wl,-unresolved-symbols=ignore-all"
+// Created by cgo - DO NOT EDIT
+
+package rocksdb
+
+import "unsafe"
+
+import _ "runtime/cgo"
+
+import "syscall"
+
+var _ syscall.Errno
+func _Cgo_ptr(ptr unsafe.Pointer) unsafe.Pointer { return ptr }
+
+//go:linkname _Cgo_always_false runtime.cgoAlwaysFalse
+var _Cgo_always_false bool
+//go:linkname _Cgo_use runtime.cgoUse
+func _Cgo_use(interface{})
+type _Ctype_void [0]byte
+
+//go:linkname _cgo_runtime_cgocall runtime.cgocall
+func _cgo_runtime_cgocall(unsafe.Pointer, uintptr) int32
+
+//go:linkname _cgo_runtime_cgocallback runtime.cgocallback
+func _cgo_runtime_cgocallback(unsafe.Pointer, unsafe.Pointer, uintptr, uintptr)
+
+//go:linkname _cgoCheckPointer runtime.cgoCheckPointer
+func _cgoCheckPointer(interface{}, ...interface{})
+
+//go:linkname _cgoCheckResult runtime.cgoCheckResult
+func _cgoCheckResult(interface{})
+


### PR DESCRIPTION
Previously crlfmt would panic when encountering a function without a
body - no longer. Also add a test for this with a previously crashing
input.