### PR TITLE
account for starting position of return types

### DIFF
--- a/testdata/_cgo_gotypes.go
+++ b/testdata/_cgo_gotypes.go
@@ -63,3 +63,10 @@ func someSigWithLongArgsAndElidedTypeShorthand(
 	someLoooooooooooooooooooooooooooooooooooooooooooooooooooooooog int,
 ) {
 }
+
+func (h *txnHeartbeat) finalTxnStatsLocked() (
+	duration, restarts int64,
+	status roachpb.TransactionStatus,
+) {
+	return
+}


### PR DESCRIPTION
when doing multi-line, we usually have the return types on a new line after the params
but if there are no params, they start on same line. We need to take that offset into account,
when deciding if we need to wrap the return types.

Fixes #19.