### PR TITLE
use printer options that match gofmt when simplifying

### DIFF
--- a/main.go
+++ b/main.go
@@ -171,8 +171,13 @@ func checkBuf(path string, src []byte) ([]byte, error) {
 				return nil, err
 			}
 			render.Simplify(f)
+
+			prCfg := &printer.Config{
+				Tabwidth: *tab,
+				Mode:     printer.UseSpaces | printer.TabIndent,
+			}
 			var buf bytes.Buffer
-			printer.Fprint(&buf, fileSet, f)
+			prCfg.Fprint(&buf, fileSet, f)
 			src = buf.Bytes()
 		}
 	}

--- a/testdata/indentation.in.go
+++ b/testdata/indentation.in.go
@@ -1,0 +1,7 @@
+package test
+
+var (
+	shouldNotMove = 0
+	shouldMove1              = 1
+shouldMove2              = 2
+)

--- a/testdata/indentation.out.go
+++ b/testdata/indentation.out.go
@@ -1,0 +1,7 @@
+package test
+
+var (
+	shouldNotMove = 0
+	shouldMove1   = 1
+	shouldMove2   = 2
+)


### PR DESCRIPTION
The default printer options in go/printer are different from those
used by gofmt. As a result, the simplify pass of crlfmt built from
master was producing whitespace changes on many files.