### PR TITLE
ignore nonexistant files/directories

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,7 +96,9 @@ func run() error {
 	}
 
 	err = filepath.Walk(root, func(path string, fi os.FileInfo, err error) error {
-		if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		} else if err != nil {
 			return err
 		}
 		if ignoreRE != nil && ignoreRE.MatchString(path) {


### PR DESCRIPTION
The call to filepath.Walk may surface an error if it observes a directory but attempting to stat it finds that it no longer exists. This type of situation is possible when running go tests for multiple packages in parallel, and some go tests create directories within the source tree. This behavior was observed in the Pebble metamorphic tests.