### PR TITLE
add flag to wrap function doc strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Flags:
   -tab <int>        tab width for column calculations (default 2)
   -w                overwrite modified files
   -wrap <int>       column to wrap at (default 100)
+  -wrapfndoc <int>  column to wrap function doc strings at (default 80, ignores multiline comments)
 ```
 
 ## Examples

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ import (
 )
 
 var (
+	wrapfndoc    = flag.Int("wrapfndoc", 80, "column to wrap function docstrings at")
 	wrap         = flag.Int("wrap", 100, "column to wrap at")
 	tab          = flag.Int("tab", 2, "tab width for column calculations")
 	overwrite    = flag.Bool("w", false, "overwrite modified files")
@@ -248,11 +249,10 @@ func checkBuf(path string, src []byte) ([]byte, error) {
 			lastPos = imp.End
 		}
 		if fn, ok := d.(*parser.FuncDecl); ok {
-			output.Write(file.Slice(lastPos, fn.Pos()))
-			lastPos = fn.BodyEnd()
 			var curFunc bytes.Buffer
-			render.Func(&curFunc, file, fn, *tab, *wrap)
+			render.Func(&curFunc, file, fn, *tab, *wrap, *wrapfndoc, lastPos)
 			output.Write(curFunc.Bytes())
+			lastPos = fn.BodyEnd()
 		}
 	}
 	output.Write(src[file.Offset(lastPos):])

--- a/testdata/comments.in.go
+++ b/testdata/comments.in.go
@@ -1,0 +1,30 @@
+package test
+
+// docstring should wrap to 80 chars test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2
+// test3 test4 test5 test6 test7 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 test4 test5
+func docstring() string
+
+// docstring with a word over 80 chars cannot be wrapped
+// verylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongword
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 verylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongword
+// test1 test2
+func docstringWithLongWords() string
+
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 aaaaa
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 bbbbb
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 ccccc
+func docstringWith80CharComments() string
+
+// This is an explanation
+// - foo
+// - bar
+func docstringWithBullets() string
+
+/*
+
+ multiline comments are unchanged  multiline comments are unchanged multiline comments are unchanged
+ multiline comments are unchanged  multiline comments are unchanged  multiline comments are unchanged
+ multiline comments are unchanged  multiline comments are unchanged  multiline comments are unchanged
+
+*/
+func multilineComment() string

--- a/testdata/comments.out.go
+++ b/testdata/comments.out.go
@@ -1,0 +1,31 @@
+package test
+
+// docstring should wrap to 80 chars test1 test2 test3 test4 test5 test6 test7
+// test8 test9 test1 test2
+// test3 test4 test5 test6 test7 test3 test4 test5 test6 test7 test8 test9 test1
+// test2 test3 test4 test5
+func docstring() string
+
+// docstring with a word over 80 chars cannot be wrapped
+// verylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongword
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2
+// verylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongword
+// test1 test2
+func docstringWithLongWords() string
+
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 aaaaa
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 bbbbb
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 ccccc
+func docstringWith80CharComments() string
+
+// This is an explanation
+// - foo
+// - bar
+func docstringWithBullets() string
+
+/*
+multiline comments are unchanged  multiline comments are unchanged multiline comments are unchanged
+multiline comments are unchanged  multiline comments are unchanged  multiline comments are unchanged
+multiline comments are unchanged  multiline comments are unchanged  multiline comments are unchanged
+*/
+func multilineComment() string


### PR DESCRIPTION
This change adds the program flag 'wrapfndoc' which wraps function
doc strings. By default, the doc strings are wrapped to 80 chars.

Noteably, this flag ignores multiline comments and does not wrap
words which are over 80 chars. This is mainly done for simplicity
and can be changed in the future.

Also, it only wraps lines in which are too long and preserves
lines which fit within 80 characters. This is different than
the `Wrap To Column` extension in Goland which greedily writes
80 chars at a time. The problem with writing chars greedily is
that it can mess up formatting. For example, a list of bullet
points gets put onto one line using `Wrap To Column`:

```
list:
- foo
- bar
- bar
```

would become
```
list: - foo - bar - baz
```

This is undesirable.

It is also worth noting that this change will not change any lines
after `Wrap To Column` is used because it ignores lines that are <=
80 chars.
