### PR TITLE
add flag to wrap docstrings for const, var, and type

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Flags:
   -tab <int>        tab width for column calculations (default 2)
   -w                overwrite modified files
   -wrap <int>       column to wrap at (default 100)
-  -wrapfndoc <int>  column to wrap function doc strings at (default 80, ignores multiline comments)
+  -wrapdoc <int>    column at which to wrap doc strings for functions, variables, constants, and types. ignores multiline comments denoted by /*
 ```
 
 ## Examples

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -88,6 +88,12 @@ func ParseFile(name string, src []byte) (*File, error) {
 					assocFieldListComments(&cr, f.Type.Results)
 				}
 			}
+		} else if g, ok := d.(*ast.GenDecl); ok && g.Tok == token.CONST {
+			decls = append(decls, &ConstDecl{*g})
+		} else if g, ok := d.(*ast.GenDecl); ok && g.Tok == token.VAR {
+			decls = append(decls, &VarDecl{*g})
+		} else if g, ok := d.(*ast.GenDecl); ok && g.Tok == token.TYPE {
+			decls = append(decls, &TypeDecl{*g})
 		}
 	}
 
@@ -179,5 +185,20 @@ type Decl interface {
 	decl()
 }
 
+type TypeDecl struct {
+	ast.GenDecl
+}
+
+type VarDecl struct {
+	ast.GenDecl
+}
+
+type ConstDecl struct {
+	ast.GenDecl
+}
+
 func (i *ImportDecl) decl() {}
 func (f *FuncDecl) decl()   {}
+func (f *ConstDecl) decl()  {}
+func (f *VarDecl) decl()    {}
+func (f *TypeDecl) decl()   {}

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ import (
 
 var (
 	// TODO: wrap doc strings for imports and floating comments.
-	wrapdoc      = flag.Int("wrapdoc", 80, "column at which to wrap doc strings for functions, variables, constants, and types. ignores multiline comments denoted by /*")
+	wrapdoc      = flag.Int("wrapdoc", 160, "column at which to wrap doc strings for functions, variables, constants, and types. ignores multiline comments denoted by /*")
 	wrap         = flag.Int("wrap", 100, "column to wrap at")
 	tab          = flag.Int("tab", 2, "tab width for column calculations")
 	overwrite    = flag.Bool("w", false, "overwrite modified files")

--- a/main_test.go
+++ b/main_test.go
@@ -31,6 +31,7 @@ func TestCheckPath(t *testing.T) {
 	*printDiff = false
 	*tab = 8
 	*groupImports = false
+	*wrapdoc = 80
 	files, err := filepath.Glob("testdata/*.in.go")
 	if err != nil {
 		t.Fatal(err)

--- a/testdata/comments.in.go
+++ b/testdata/comments.in.go
@@ -2,6 +2,8 @@ package test
 
 // docstring should wrap to 80 chars test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2
 // test3 test4 test5 test6 test7 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 test4 test5
+//
+// test3 test4 test5 test6 test7 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 test4 test5
 func docstring() string
 
 // docstring with a word over 80 chars cannot be wrapped
@@ -21,10 +23,106 @@ func docstringWith80CharComments() string
 func docstringWithBullets() string
 
 /*
-
- multiline comments are unchanged  multiline comments are unchanged multiline comments are unchanged
- multiline comments are unchanged  multiline comments are unchanged  multiline comments are unchanged
- multiline comments are unchanged  multiline comments are unchanged  multiline comments are unchanged
-
+multiline comments are unchanged  multiline comments are unchanged multiline comments are unchanged
+multiline comments are unchanged  multiline comments are unchanged  multiline comments are unchanged
+multiline comments are unchanged  multiline comments are unchanged  multiline comments are unchanged
 */
 func multilineComment() string
+
+// docstring should wrap to 80 chars test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2
+// test3 test4 test5 test6 test7 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 test4 test5
+type docstring string
+
+// docstring with a word over 80 chars cannot be wrapped
+// verylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongword
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 verylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongword
+// test1 test2
+type longWords struct {
+	s string
+}
+
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 aaaaa
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 bbbbb
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 ccccc
+type eightyCharLines struct {
+	s string
+}
+
+// This is an explanation
+// - foo
+// - bar
+type bullets struct {
+	s string
+}
+
+/*
+multiline comments are unchanged  multiline comments are unchanged multiline comments are unchanged
+multiline comments are unchanged  multiline comments are unchanged  multiline comments are unchanged
+multiline comments are unchanged  multiline comments are unchanged  multiline comments are unchanged
+*/
+type multiline struct {
+	s string
+}
+
+// docstring should wrap to 80 chars test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2
+// test3 test4 test5 test6 test7 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 test4 test5
+const docstring = ""
+
+// docstring with a word over 80 chars cannot be wrapped
+// verylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongword
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 verylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongword
+// test1 test2
+const longWords = "asdf"
+
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 aaaaa
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 bbbbb
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 ccccc
+const eightyCharLines = 80
+
+// This is an explanation
+// - foo
+// - bar
+const bullets = `foo
+  bar
+baz
+`
+
+/*
+multiline comments are unchanged  multiline comments are unchanged multiline comments are unchanged
+multiline comments are unchanged  multiline comments are unchanged  multiline comments are unchanged
+multiline comments are unchanged  multiline comments are unchanged  multiline comments are unchanged
+*/
+const multiline = `foo
+  bar
+baz
+`
+
+// docstring should wrap to 80 chars test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2
+// test3 test4 test5 test6 test7 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 test4 test5
+var docstring = struct{ string }{}
+
+// docstring with a word over 80 chars cannot be wrapped
+// verylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongword
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 verylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongword
+// test1 test2
+var longWords = [10]int{}
+
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 aaaaa
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 bbbbb
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 ccccc
+var eightyCharLines = 80
+
+// This is an explanation
+// - foo
+// - bar
+var bullets = `foo
+  bar
+baz
+`
+
+/*
+multiline comments are unchanged  multiline comments are unchanged multiline comments are unchanged
+multiline comments are unchanged  multiline comments are unchanged  multiline comments are unchanged
+multiline comments are unchanged  multiline comments are unchanged  multiline comments are unchanged
+*/
+var multiline = make(map[string]int)

--- a/testdata/comments.out.go
+++ b/testdata/comments.out.go
@@ -4,6 +4,9 @@ package test
 // test8 test9 test1 test2
 // test3 test4 test5 test6 test7 test3 test4 test5 test6 test7 test8 test9 test1
 // test2 test3 test4 test5
+//
+// test3 test4 test5 test6 test7 test3 test4 test5 test6 test7 test8 test9 test1
+// test2 test3 test4 test5
 func docstring() string
 
 // docstring with a word over 80 chars cannot be wrapped
@@ -29,3 +32,110 @@ multiline comments are unchanged  multiline comments are unchanged  multiline co
 multiline comments are unchanged  multiline comments are unchanged  multiline comments are unchanged
 */
 func multilineComment() string
+
+// docstring should wrap to 80 chars test1 test2 test3 test4 test5 test6 test7
+// test8 test9 test1 test2
+// test3 test4 test5 test6 test7 test3 test4 test5 test6 test7 test8 test9 test1
+// test2 test3 test4 test5
+type docstring string
+
+// docstring with a word over 80 chars cannot be wrapped
+// verylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongword
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2
+// verylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongword
+// test1 test2
+type longWords struct {
+	s string
+}
+
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 aaaaa
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 bbbbb
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 ccccc
+type eightyCharLines struct {
+	s string
+}
+
+// This is an explanation
+// - foo
+// - bar
+type bullets struct {
+	s string
+}
+
+/*
+multiline comments are unchanged  multiline comments are unchanged multiline comments are unchanged
+multiline comments are unchanged  multiline comments are unchanged  multiline comments are unchanged
+multiline comments are unchanged  multiline comments are unchanged  multiline comments are unchanged
+*/
+type multiline struct {
+	s string
+}
+
+// docstring should wrap to 80 chars test1 test2 test3 test4 test5 test6 test7
+// test8 test9 test1 test2
+// test3 test4 test5 test6 test7 test3 test4 test5 test6 test7 test8 test9 test1
+// test2 test3 test4 test5
+const docstring = ""
+
+// docstring with a word over 80 chars cannot be wrapped
+// verylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongword
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2
+// verylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongword
+// test1 test2
+const longWords = "asdf"
+
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 aaaaa
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 bbbbb
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 ccccc
+const eightyCharLines = 80
+
+// This is an explanation
+// - foo
+// - bar
+const bullets = `foo
+  bar
+baz
+`
+
+/*
+multiline comments are unchanged  multiline comments are unchanged multiline comments are unchanged
+multiline comments are unchanged  multiline comments are unchanged  multiline comments are unchanged
+multiline comments are unchanged  multiline comments are unchanged  multiline comments are unchanged
+*/
+const multiline = `foo
+  bar
+baz
+`
+
+// docstring should wrap to 80 chars test1 test2 test3 test4 test5 test6 test7
+// test8 test9 test1 test2
+// test3 test4 test5 test6 test7 test3 test4 test5 test6 test7 test8 test9 test1
+// test2 test3 test4 test5
+var docstring = struct{ string }{}
+
+// docstring with a word over 80 chars cannot be wrapped
+// verylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongword
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2
+// verylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongwordverylongword
+// test1 test2
+var longWords = [10]int{}
+
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 aaaaa
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 bbbbb
+// test1 test2 test3 test4 test5 test6 test7 test8 test9 test1 test2 test3 ccccc
+var eightyCharLines = 80
+
+// This is an explanation
+// - foo
+// - bar
+var bullets = `foo
+  bar
+baz
+`
+
+/*
+multiline comments are unchanged  multiline comments are unchanged multiline comments are unchanged
+multiline comments are unchanged  multiline comments are unchanged  multiline comments are unchanged
+multiline comments are unchanged  multiline comments are unchanged  multiline comments are unchanged
+*/
+var multiline = make(map[string]int)


### PR DESCRIPTION
#### add flag to wrap docstrings for const, var, and type

In https://github.com/cockroachdb/crlfmt/pull/44, this program was extended to be able to wrap function doc strings using the flag `wrapfndoc`. This change extends the flag to wrap doc strings for var, const, and type declarations. This change also renames the flag to `wrapdoc`.

---

#### default doc string wrapping to 160 chars

See https://github.com/cockroachdb/crlfmt/pull/44#issuecomment-1532344650.
Presently, in the pebble repository, there are violations of docstrings being
limited to 80 chars. This change updates the default to 160 chars to prevent CI
from failing.