### PR TITLE
Allow multiple files to be passed at once

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.19
 
 require (
 	github.com/cockroachdb/gostdlib v1.19.0
-	github.com/cockroachdb/ttycolor v0.0.0-20180709150743-a1d5aaeb377d
 	github.com/stretchr/testify v1.6.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/cockroachdb/gostdlib v1.19.0 h1:cSISxkVnTlWhTkyple/T6NXzOi5659FkhxvUgZv+Eb0=
 github.com/cockroachdb/gostdlib v1.19.0/go.mod h1:+dqqpARXbE/gRDEhCak6dm0l14AaTymPZUKMfURjBtY=
-github.com/cockroachdb/ttycolor v0.0.0-20180709150743-a1d5aaeb377d h1:TNsiMS1Ij2aleP/05UNSPzsOu9eJm9mfUGLm7Ylt7Dg=
-github.com/cockroachdb/ttycolor v0.0.0-20180709150743-a1d5aaeb377d/go.mod h1:NltwFG0VBANi1jHKpn5KL9AbsHTE+8fPaAHT0TzL20k=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 	goparser "go/parser"
 	"go/printer"
 	"go/token"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/crlfmt/internal/render"
 	"github.com/cockroachdb/gostdlib/go/format"
 	"github.com/cockroachdb/gostdlib/x/tools/imports"
-	"github.com/cockroachdb/ttycolor"
 )
 
 var (
@@ -47,12 +46,6 @@ var (
 	srcDir       = flag.String("srcdir", "", "resolve imports as if the source file is from the given directory (if a file is given, the parent directory is used)")
 )
 
-var (
-	red   = string(ttycolor.StdoutProfile[ttycolor.Red])
-	green = string(ttycolor.StdoutProfile[ttycolor.Green])
-	reset = string(ttycolor.StdoutProfile[ttycolor.Reset])
-)
-
 func main() {
 	if err := run(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %s\n", err)
@@ -64,7 +57,7 @@ func run() error {
 	flag.Parse()
 
 	if flag.NArg() == 0 {
-		content, err := ioutil.ReadAll(os.Stdin)
+		content, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}
@@ -126,7 +119,7 @@ func run() error {
 }
 
 func checkPath(path string) error {
-	src, err := ioutil.ReadFile(path)
+	src, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
@@ -147,7 +140,7 @@ func checkPath(path string) error {
 		}
 
 		if *overwrite {
-			err := ioutil.WriteFile(path, output, 0)
+			err := os.WriteFile(path, output, 0)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Previously, only a single path or file name could be passed at once. This was problematic for using crlfmt for tools like lint-staged which expect to be able to pass a list of modified files.  We now support passing any number of files.