### PR TITLE
fix nil pointer for long signature without params

### DIFF
--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -234,7 +234,7 @@ func Func(w io.Writer, f *parser.File, fn *parser.FuncDecl, tabSize, wrapBody, w
 		if (singleLineResultsLen <= wrapBody || exactlyOneResult) && !resultsHaveComments {
 			w.Write(resultsJoined)
 			fmt.Fprint(w, funcEnd)
-		} else {
+		} else if results != nil {
 			fmt.Fprintln(w)
 			for _, result := range results.List {
 				renderLineFuncField(w, f, result)

--- a/main_test.go
+++ b/main_test.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -38,7 +38,7 @@ func TestCheckPath(t *testing.T) {
 	}
 	for _, file := range files {
 		t.Run(filepath.Base(file), func(t *testing.T) {
-			inBytes, err := ioutil.ReadFile(file)
+			inBytes, err := os.ReadFile(file)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -49,10 +49,10 @@ func TestCheckPath(t *testing.T) {
 				t.Fatal(err)
 			}
 			if *rewrite {
-				err := ioutil.WriteFile(outFile, output, 0666)
+				err := os.WriteFile(outFile, output, 0666)
 				require.NoError(t, err)
 			} else {
-				expBytes, err := ioutil.ReadFile(outFile)
+				expBytes, err := os.ReadFile(outFile)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/testdata/funcsigs.in.go
+++ b/testdata/funcsigs.in.go
@@ -1,5 +1,8 @@
 package test
 
+func signatureWithoutParametersButLongerThanTheWrapLength123456789123456789123456789123456789123456789() {
+}
+
 func someSignatureThatIs100Chars____________________________________(someArg, someOtherArg string) {
 }
 

--- a/testdata/funcsigs.out.go
+++ b/testdata/funcsigs.out.go
@@ -1,5 +1,8 @@
 package test
 
+func signatureWithoutParametersButLongerThanTheWrapLength123456789123456789123456789123456789123456789() {
+}
+
 func someSignatureThatIs100Chars____________________________________(someArg, someOtherArg string) {
 }
 


### PR DESCRIPTION
If a signature was longer than the wrap length and didn't have parameters, there was a panic. We now check for this case explicitly.  The tests have been updated with an appropriate test.  I've also added a commit to updated deprecated function calls from main_test.go.