### PR TITLE
bump minimum Go version to 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cockroachdb/crlfmt
 
-go 1.19
+go 1.26
 
 require (
 	github.com/cockroachdb/gostdlib v1.19.0

--- a/testdata/imports_comments.out.go
+++ b/testdata/imports_comments.out.go
@@ -12,25 +12,17 @@ import (
 	"f"
 	"g"
 	"h" // a line comment
+	// interleaved comment to be preserved
+	// import doc block comment to be removed
+	// b line comment
+	// d doc comment
+	// e doc comment
+	// e line comment
+	// f doc comment
+	// f line comment
+	// g line comment
+	// import doc comment to be deleted; there's nothing sensible we can do with it
 )
-
-// interleaved comment to be preserved
-
-// import doc block comment to be removed
-
-// b line comment
-
-// d doc comment
-
-// e doc comment
-// e line comment
-
-// f doc comment
-// f line comment
-
-// g line comment
-
-// import doc comment to be deleted; there's nothing sensible we can do with it
 
 var _ = a.Foo
 var _ = b.Foo


### PR DESCRIPTION
Update the expected test output for imports_comments to match the goimports behavior in Go 1.26, which represents comments in merged import blocks differently.
