### PR TITLE
ci: add GitHub Actions, golangci-lint, and GoReleaser

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Keep Go module dependencies up to date.
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  # Keep GitHub Actions pinned versions up to date.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,95 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+# Cancel in-progress runs for the same PR/branch when new commits are pushed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test -race -count=1 ./...
+
+  vet:
+    name: Vet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go mod tidy is clean
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # needed for new-from-merge-base to find the base ref
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.12.2
+
+  crlfmt:
+    name: crlfmt (self-check)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # Dogfood: crlfmt formats its own source. -diff prints a diff but exits 0,
+      # so fail the job if the output is non-empty. testdata/ holds intentionally
+      # unformatted fixtures, so it is excluded.
+      - name: Run crlfmt on itself
+        run: |
+          go install .
+          diff=$(crlfmt -diff -ignore 'testdata/' .)
+          if [ -n "$diff" ]; then
+            echo "crlfmt would reformat the following:"
+            echo "$diff"
+            echo "::error::Run 'crlfmt -w -ignore testdata/ .' and commit the result."
+            exit 1
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write # needed to create the GitHub Release and upload assets
+
+jobs:
+  goreleaser:
+    name: GoReleaser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history is required for the changelog
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+# golangci-lint v2 configuration.
+# Docs: https://golangci-lint.run/docs/configuration/file/
+version: "2"
+
+linters:
+  # Default linters (errcheck, govet, ineffassign, staticcheck, unused) stay
+  # enabled; these are the extras we opt into.
+  enable:
+    - misspell    # common misspellings
+    - revive      # style/lint replacement for the old golint
+
+issues:
+  # Report every issue, not just a sample.
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  # Only flag issues introduced by the code a PR changes; the repo's existing
+  # findings are grandfathered. Drop this once they've been cleaned up.
+  new-from-merge-base: origin/master

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,44 @@
+# GoReleaser v2 configuration.
+# Docs: https://goreleaser.com
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+
+archives:
+  - formats: [tar.gz]
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    # Windows gets a .zip instead of a tarball.
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "Merge pull request"
+
+release:
+  draft: false

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -133,7 +133,13 @@ func renderLineFuncField(w io.Writer, f *parser.File, param *ast.Field) {
 // Func renders the function fn into w. The function is wrapped so that no line
 // exceeds past the wrap column wrapCol when tabs are rendered with specified
 // tab size.
-func Func(w io.Writer, f *parser.File, fn *parser.FuncDecl, tabSize, wrapBody, wrapDocString int, lastPos token.Pos) {
+func Func(
+	w io.Writer,
+	f *parser.File,
+	fn *parser.FuncDecl,
+	tabSize, wrapBody, wrapDocString int,
+	lastPos token.Pos,
+) {
 	params := fn.Type.Params
 	results := fn.Type.Results
 
@@ -257,7 +263,9 @@ func GenDecl(w io.Writer, f *parser.File, decl ast.GenDecl, wrapDocString int, l
 // DocString renders a docstring from lastPos to nextPos where lastPos is
 // the end of the previous Decl and next pos is the start of the Decl
 // corresponding to this doc string.
-func DocString(w io.Writer, f *parser.File, doc *ast.CommentGroup, wrapDocString int, lastPos, nextPos token.Pos) {
+func DocString(
+	w io.Writer, f *parser.File, doc *ast.CommentGroup, wrapDocString int, lastPos, nextPos token.Pos,
+) {
 	w.Write(f.Slice(lastPos, doc.Pos()))
 	if strings.Fields(doc.List[0].Text)[0] != "/*" {
 		for i, c := range doc.List {


### PR DESCRIPTION
Add CI and release automation for the project:

- .github/workflows/ci.yaml: run on PRs and pushes to master with test (go test -race), vet (go vet + go mod tidy check), lint (golangci-lint v2.12.2), and a crlfmt self-check that dogfoods the formatter on its own source (excluding testdata fixtures).
- .golangci.yml: golangci-lint v2 config enabling misspell and revive on top of the defaults; new-from-merge-base grandfathers the repo's existing findings so only new code is gated.
- .goreleaser.yaml + .github/workflows/release.yaml: cross-platform release builds published to GitHub Releases on v* tags.
- .github/dependabot.yml: weekly updates for Go modules and Actions.

Format internal/render/render.go with crlfmt so the self-check passes.