### PR TITLE
main: add -formatonly flag to avoid go toolchain dependency

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,7 +41,8 @@ var (
 	wrap         = flag.Int("wrap", 100, "column to wrap at")
 	tab          = flag.Int("tab", 2, "tab width for column calculations")
 	overwrite    = flag.Bool("w", false, "overwrite modified files")
-	fast         = flag.Bool("fast", false, "skip running goimports and simplify")
+	fast         = flag.Bool("fast", false, "skip running goimports/gofmt and simplify")
+	formatOnly   = flag.Bool("formatonly", false, "format imports without resolving them; avoids requiring the go toolchain at runtime, but does not add missing or remove unused imports")
 	groupImports = flag.Bool("groupimports", true, "group imports by type")
 	printDiff    = flag.Bool("diff", true, "print diffs")
 	ignore       = flag.String("ignore", "", "regex matching files to skip")
@@ -163,7 +164,7 @@ func checkBuf(path string, src []byte) ([]byte, error) {
 			Comments:   true,
 			TabIndent:  false,
 			TabWidth:   *tab,
-			FormatOnly: false,
+			FormatOnly: *formatOnly,
 		}
 
 		if localPrefix != nil && *localPrefix != "" {


### PR DESCRIPTION
Previously, crlfmt's default path ran goimports with import resolution
enabled, which shells out to the go toolchain (`go env`, `go list`) to
add missing and remove unused imports. This made a go toolchain a
runtime requirement; without `go` on `$PATH`, crlfmt failed with
"go command required, not found".

This adds a `-formatonly` flag that sets goimports' `FormatOnly` option,
which skips import resolution. With the flag, crlfmt still applies gofmt
formatting, the simplify pass, signature wrapping, and import grouping,
but no longer requires the go toolchain. The trade-off is that missing
imports are not added and unused imports are not removed, since that
resolution fundamentally needs the module graph.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>