### PR TITLE
README: fix CockroachDB Style Guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # crlfmt
 
-`crlfmt` is a `gofmt`-style linter for Go code that enforces the CockroachDB Style Guide found [here](https://wiki.crdb.io/wiki/spaces/CRDB/pages/181371303/Go+coding+guidelines).
+`crlfmt` is a `gofmt`-style linter for Go code that enforces the CockroachDB Style Guide found [here](https://github.com/cockroachdb/cockroach/blob/master/docs/style.md).
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Update the CockroachDB Style Guide link in the README from the stale wiki URL to the canonical location at `cockroach/docs/style.md`

Fixes #59